### PR TITLE
fix: remove zsh from build, add PR build check

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,22 @@
+name: CI
+
+on:
+  pull_request:
+    branches: [main]
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: npm
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Build
+        run: npm run build

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,10 +13,9 @@ jobs:
       - uses: actions/setup-node@v4
         with:
           node-version: 20
-          cache: npm
 
       - name: Install dependencies
-        run: npm ci
+        run: npm install
 
       - name: Build
         run: npm run build

--- a/package.json
+++ b/package.json
@@ -4,8 +4,8 @@
   "version": "0.0.0",
   "type": "module",
   "scripts": {
-    "dev": "zsh scripts/generate-thumbnails.sh && vite",
-    "build": "zsh scripts/generate-thumbnails.sh && tsc -b && vite build",
+    "dev": "vite",
+    "build": "tsc -b && vite build",
     "lint": "eslint .",
     "preview": "vite preview"
   },


### PR DESCRIPTION
## Summary
- Removes `zsh scripts/generate-thumbnails.sh` from `dev` and `build` scripts — `zsh` isn't available in CI environments
- Adds `.github/workflows/ci.yml` to run `npm run build` on every PR to catch build failures before merge

## Test plan
- [ ] Verify this PR itself passes the new CI check
- [ ] Confirm `npm run dev` and `npm run build` work locally without the script prefix

🤖 Generated with [Claude Code](https://claude.com/claude-code)